### PR TITLE
Hotfix for persistent user session issues

### DIFF
--- a/src/routes/+page.server.ts
+++ b/src/routes/+page.server.ts
@@ -1,9 +1,0 @@
-// src/routes/+page.server.ts
-import type { PageServerLoad } from './$types';
-
-export const ssr = true;
-export const prerender = true;
-
-export const load: PageServerLoad = async () => {
-  return {};
-};

--- a/src/routes/faq/+page.ts
+++ b/src/routes/faq/+page.ts
@@ -1,2 +1,0 @@
-export const ssr = true;
-export const prerender = true; 

--- a/src/routes/leaderboard/+page.server.ts
+++ b/src/routes/leaderboard/+page.server.ts
@@ -2,9 +2,6 @@ import { fail, error } from '@sveltejs/kit';
 import type { RequestEvent } from "./$types.js";
 import { getFullLeaderboard } from '$lib/server/services/leaderboardService';
 
-export const ssr = true;
-export const prerender = true; 
-
 export async function load(event: RequestEvent) {
     const rankings : any = await getFullLeaderboard();
     const leaderboard = await rankings.map((rank : any) => {


### PR DESCRIPTION
User sessions were not persisting correctly due to ssr/prerender causing header to update incorrectly.